### PR TITLE
Fix: panel resizing created jankiness with dynamically sized widgets in the panel

### DIFF
--- a/package/contents/ui/Cava.qml
+++ b/package/contents/ui/Cava.qml
@@ -38,6 +38,7 @@ Item {
     readonly property list<string> loadingErrors: process.loadingErrors
     readonly property bool loadingFailed: process.loadingFailed
     readonly property bool usingFallback: process.usingFallback
+    property bool restarting: false
     readonly property bool running: process.running
     readonly property string cavaCommand: process.command
     readonly property string cavaConfig: {
@@ -103,6 +104,7 @@ waves=${root.waves}
     }
     onCavaConfigChanged: {
         if (barCount > 0 && cavaConfig != "") {
+            root.restarting = true;
             process.command = `exec cava -p /dev/stdin <<-EOF
 ${cavaConfig}
 EOF
@@ -111,6 +113,11 @@ EOF
     }
     ProcessMonitor {
         id: process
+        onRunningChanged: {
+            if (process.running) {
+                root.restarting = false;
+            }
+        }
         onStdoutChanged: {
             let output = process.stdout.trim();
             if (output.endsWith(';')) {

--- a/package/contents/ui/components/Visualizer.qml
+++ b/package/contents/ui/components/Visualizer.qml
@@ -25,6 +25,7 @@ Item {
     required property var inactiveBlockColorsCfg
     required property bool drawInactiveBlocks
     required property bool fixVertical
+    required property bool restarting
     property list<int> values
     property bool debugMode: false
 
@@ -133,8 +134,7 @@ Item {
         property bool fixAlign: barWidth % 2 === 0 && centeredBars && visualizerStyle === Enum.VisualizerStyles.Wave && !root.fixVertical
 
         onValuesChanged: {
-              if (root.values !== undefined && root.values.length > 1) {
-                console.log("The values were changed: "+ root.values.length)
+              if (root.values !== undefined && root.values.length > 1 && root.restarting) {
                 canvas.requestPaint()
                 }
               }

--- a/package/contents/ui/components/Visualizer.qml
+++ b/package/contents/ui/components/Visualizer.qml
@@ -67,7 +67,7 @@ Item {
             }
             return root.barGap;
         }
-        property int barCount: root.values.length
+        property int barCount:0
           
         
         property bool centeredBars: root.centeredBars
@@ -134,6 +134,9 @@ Item {
 
         onValuesChanged: {
               if (root.values !== undefined && root.values.length > 1) {
+                if(root.values.length !== barCount){
+                  barCount = root.values.length
+                }
                 canvas.requestPaint()
                 }
               }

--- a/package/contents/ui/components/Visualizer.qml
+++ b/package/contents/ui/components/Visualizer.qml
@@ -25,7 +25,6 @@ Item {
     required property var inactiveBlockColorsCfg
     required property bool drawInactiveBlocks
     required property bool fixVertical
-    required property bool restarting
     property list<int> values
     property bool debugMode: false
 
@@ -134,7 +133,7 @@ Item {
         property bool fixAlign: barWidth % 2 === 0 && centeredBars && visualizerStyle === Enum.VisualizerStyles.Wave && !root.fixVertical
 
         onValuesChanged: {
-              if (root.values !== undefined && root.values.length > 1 && root.restarting) {
+              if (root.values !== undefined && root.values.length > 1) {
                 canvas.requestPaint()
                 }
               }

--- a/package/contents/ui/components/Visualizer.qml
+++ b/package/contents/ui/components/Visualizer.qml
@@ -68,6 +68,8 @@ Item {
             return root.barGap;
         }
         property int barCount: root.values.length
+          
+        
         property bool centeredBars: root.centeredBars
         property bool roundedBars: root.roundedBars
         property var values: {
@@ -130,7 +132,12 @@ Item {
         height: parent.height
         property bool fixAlign: barWidth % 2 === 0 && centeredBars && visualizerStyle === Enum.VisualizerStyles.Wave && !root.fixVertical
 
-        onValuesChanged: canvas.requestPaint()
+        onValuesChanged: {
+              if (root.values !== undefined && root.values.length > 1) {
+                console.log("The values were changed: "+ root.values.length)
+                canvas.requestPaint()
+                }
+              }
 
         onPaint: {
             const ctx = getContext("2d");

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -66,7 +66,7 @@ PlasmoidItem {
             if (Plasmoid.status === PlasmaCore.Types.RequiresAttentionStatus) {
                 return;
             }
-            Plasmoid.status = (hideWhenIdle && cava.idle || !cava.running) && !Plasmoid.expanded && !editMode && !cava.hasError ? PlasmaCore.Types.HiddenStatus : PlasmaCore.Types.ActiveStatus;
+            Plasmoid.status = (hideWhenIdle && cava.idle || (!cava.running && !cava.restarting)) && !Plasmoid.expanded && !editMode && !cava.hasError ? PlasmaCore.Types.HiddenStatus : PlasmaCore.Types.ActiveStatus;
             logger.debug("Plasmoid.status:", Plasmoid.status);
         }, main);
     }


### PR DESCRIPTION
Follow-up to #173  fixing two issues that surfaced when the panel is resized and the bar count needs to be recalculated:

1. Flicker on restart:  Resizing triggers a Cava restart, which briefly disabled the widget. This caused a visible flicker and let the panel recalculate sizing incorrectly mid-transition. Added a restarting flag so the widget doesn't disable itself during these intentional, resize-triggered restarts.

2. Zero-length bar array during restart: While Cava restarts, `barCount` briefly reports 0, which fed bad values into the canvas repaint. The canvas now only repaints when the value array length is greater than 1, so instead of flickering off and on, the visualization freezes on its last frame and resumes once Cava is back up.