### PR TITLE
Fix incorrect stop calculation

### DIFF
--- a/package/contents/ui/code/utils.js
+++ b/package/contents/ui/code/utils.js
@@ -84,7 +84,8 @@ function buildCanvasGradient(ctx, smooth, gradientStops, orientation, height, wi
   for (let i = 0; i < gradientStops.length; i++) {
     const stop = gradientStops[i];
     let color = stop.color ?? stop;
-    let position = stop.position ?? (1 / gradientStops.length) * i;
+	// If position is undefined, check if the length is greater than one. If so, use the regular calculation, otherwise 0 to avoid divide by zero error
+    let position = stop.position ?? (gradientStops.length > 1 ? (1 / gradientStops.length - 1) * i : 0);
     gradient.addColorStop(position, color);
     if (!smooth && i > 0 && i < gradientStops.length) {
       let prevStop = gradientStops[i - 1];

--- a/package/contents/ui/code/utils.js
+++ b/package/contents/ui/code/utils.js
@@ -84,8 +84,15 @@ function buildCanvasGradient(ctx, smooth, gradientStops, orientation, height, wi
   for (let i = 0; i < gradientStops.length; i++) {
     const stop = gradientStops[i];
     let color = stop.color ?? stop;
-	// If position is undefined, check if the length is greater than one. If so, use the regular calculation, otherwise 0 to avoid divide by zero error
-    let position = stop.position ?? (gradientStops.length > 1 ? (1 / (gradientStops.length - 1)) * i : 0);
+	let position;
+	if (smooth)
+	{
+      position = stop.position ?? (gradientStops.length > 1 ? (i / (gradientStops.length - 1)) : 0);
+	}
+	else
+	{
+	  position = stop.position ?? (i / gradientStops.length);
+	}
     gradient.addColorStop(position, color);
     if (!smooth && i > 0 && i < gradientStops.length) {
       let prevStop = gradientStops[i - 1];

--- a/package/contents/ui/code/utils.js
+++ b/package/contents/ui/code/utils.js
@@ -84,12 +84,12 @@ function buildCanvasGradient(ctx, smooth, gradientStops, orientation, height, wi
   for (let i = 0; i < gradientStops.length; i++) {
     const stop = gradientStops[i];
     let color = stop.color ?? stop;
-	let position;
-	if (smooth) {
+    let position;
+    if (smooth) {
       position = stop.position ?? (gradientStops.length > 1 ? (i / (gradientStops.length - 1)) : 0);
-	} else {
-	  position = stop.position ?? (i / gradientStops.length);
-	}
+    } else {
+      position = stop.position ?? (i / gradientStops.length);
+    }
     gradient.addColorStop(position, color);
     if (!smooth && i > 0 && i < gradientStops.length) {
       let prevStop = gradientStops[i - 1];

--- a/package/contents/ui/code/utils.js
+++ b/package/contents/ui/code/utils.js
@@ -85,7 +85,7 @@ function buildCanvasGradient(ctx, smooth, gradientStops, orientation, height, wi
     const stop = gradientStops[i];
     let color = stop.color ?? stop;
 	// If position is undefined, check if the length is greater than one. If so, use the regular calculation, otherwise 0 to avoid divide by zero error
-    let position = stop.position ?? (gradientStops.length > 1 ? (1 / gradientStops.length - 1) * i : 0);
+    let position = stop.position ?? (gradientStops.length > 1 ? (1 / (gradientStops.length - 1)) * i : 0);
     gradient.addColorStop(position, color);
     if (!smooth && i > 0 && i < gradientStops.length) {
       let prevStop = gradientStops[i - 1];

--- a/package/contents/ui/code/utils.js
+++ b/package/contents/ui/code/utils.js
@@ -85,12 +85,9 @@ function buildCanvasGradient(ctx, smooth, gradientStops, orientation, height, wi
     const stop = gradientStops[i];
     let color = stop.color ?? stop;
 	let position;
-	if (smooth)
-	{
+	if (smooth) {
       position = stop.position ?? (gradientStops.length > 1 ? (i / (gradientStops.length - 1)) : 0);
-	}
-	else
-	{
+	} else {
 	  position = stop.position ?? (i / gradientStops.length);
 	}
     gradient.addColorStop(position, color);


### PR DESCRIPTION
This should be a simple pull request. It changes the stop positions to include 0 and 1 rather than exclude 1. If I'm missing any other locations where the stop is being calculated, updating those should be an easy fix.